### PR TITLE
Update old versions and correct spring boot usage

### DIFF
--- a/spring-boot-vaadin-multi/build.gradle
+++ b/spring-boot-vaadin-multi/build.gradle
@@ -9,7 +9,8 @@ buildscript {
     }
     dependencies {
     
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.5.RELEASE")
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.5.1.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE'
         
     }
 }
@@ -20,6 +21,14 @@ allprojects {
     group = 'net.knacht'
 
     version = '0.0.1'
+
+    apply plugin: "io.spring.dependency-management"
+
+    dependencyManagement {
+        imports {
+            mavenBom 'org.springframework.boot:spring-boot-starter-parent:1.5.1.RELEASE'
+        }
+    }
 
     repositories() {
     
@@ -45,8 +54,6 @@ subprojects {
 
     apply plugin: 'java'
 
-    apply plugin: 'spring-boot'
-
     sourceCompatibility = 1.8
 
     targetCompatibility = 1.8
@@ -54,12 +61,12 @@ subprojects {
     dependencies {
 
         // Spring Boot
-        compile("org.springframework.boot:spring-boot-starter-web:1.1.+")
+        compile 'org.springframework.boot:spring-boot-starter-web:1.5.1.RELEASE'
         
     }
 }
 
 task wrapper(type: Wrapper) {
 
-    gradleVersion = '2.0'
+    gradleVersion = '3.3'
 }

--- a/spring-boot-vaadin-multi/gradle/wrapper/gradle-wrapper.properties
+++ b/spring-boot-vaadin-multi/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/spring-boot-vaadin-multi/net.knacht.bootstrap.application.service/src/main/java/net/knacht/bootstrap/application/service/impl/ExampleService.java
+++ b/spring-boot-vaadin-multi/net.knacht.bootstrap.application.service/src/main/java/net/knacht/bootstrap/application/service/impl/ExampleService.java
@@ -14,14 +14,13 @@
 
 package net.knacht.bootstrap.application.service.impl;
 
-import net.knacht.bootstrap.application.model.Person;
-import net.knacht.bootstrap.application.service.api.IExampleService;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
+
+import net.knacht.bootstrap.application.model.Person;
+import net.knacht.bootstrap.application.service.api.IExampleService;
 
 /**
  * @author Tobias Placht (dev@knacht.net)
@@ -53,6 +52,6 @@ public class ExampleService implements IExampleService {
 
 	@Override
 	public Person findByName(String name) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException("Not implemented");
 	}
 }

--- a/spring-boot-vaadin-multi/net.knacht.bootstrap.application.ui.vaadin/build.gradle
+++ b/spring-boot-vaadin-multi/net.knacht.bootstrap.application.ui.vaadin/build.gradle
@@ -1,14 +1,14 @@
 dependencies {
-
+    def vaadinVersion = '7.7.6'
     // Vaadin
-    compile 'com.vaadin:vaadin-client-compiled:7.2.+'
-    compile 'com.vaadin:vaadin-client:7.2.+'
-    compile 'com.vaadin:vaadin-themes:7.2.+'
-    compile 'com.vaadin:vaadin-push:7.2.+'
-    compile 'com.vaadin:vaadin-server:7.2.+'
+    compile "com.vaadin:vaadin-client-compiled:$vaadinVersion"
+    compile "com.vaadin:vaadin-client:$vaadinVersion"
+    compile "com.vaadin:vaadin-themes:$vaadinVersion"
+    compile "com.vaadin:vaadin-push:$vaadinVersion"
+    compile "com.vaadin:vaadin-server:$vaadinVersion"
         
     // vaadin4spring
-    compile 'org.vaadin.spring:spring-boot-vaadin:0.0.2-SNAPSHOT'
+    compile 'org.vaadin.spring:spring-boot-vaadin:0.0.5.RELEASE'
     
     compile project (':net.knacht.bootstrap.application.service')
 }

--- a/spring-boot-vaadin-multi/net.knacht.bootstrap.application.ui.vaadin/src/main/java/net/knacht/bootstrap/application/ui/vaadin/ExampleUI.java
+++ b/spring-boot-vaadin-multi/net.knacht.bootstrap.application.ui.vaadin/src/main/java/net/knacht/bootstrap/application/ui/vaadin/ExampleUI.java
@@ -15,7 +15,7 @@
 package net.knacht.bootstrap.application.ui.vaadin;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.vaadin.spring.VaadinUI;
+import org.vaadin.spring.annotation.VaadinUI;
 import org.vaadin.spring.navigator.SpringViewProvider;
 
 import com.vaadin.annotations.Title;

--- a/spring-boot-vaadin-multi/net.knacht.bootstrap.application.ui.vaadin/src/main/java/net/knacht/bootstrap/application/ui/vaadin/views/MainView.java
+++ b/spring-boot-vaadin-multi/net.knacht.bootstrap.application.ui.vaadin/src/main/java/net/knacht/bootstrap/application/ui/vaadin/views/MainView.java
@@ -16,18 +16,18 @@ package net.knacht.bootstrap.application.ui.vaadin.views;
 
 import java.util.List;
 
-import net.knacht.bootstrap.application.model.Person;
-import net.knacht.bootstrap.application.service.api.IExampleService;
-import net.knacht.bootstrap.application.ui.vaadin.ExampleUI;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
-import org.vaadin.spring.navigator.VaadinView;
+import org.vaadin.spring.navigator.annotation.VaadinView;
 
 import com.vaadin.navigator.View;
 import com.vaadin.navigator.ViewChangeListener.ViewChangeEvent;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
+
+import net.knacht.bootstrap.application.model.Person;
+import net.knacht.bootstrap.application.service.api.IExampleService;
+import net.knacht.bootstrap.application.ui.vaadin.ExampleUI;
 
 @Scope("prototype")
 @VaadinView(name = "main", ui = ExampleUI.class)

--- a/spring-boot-vaadin-multi/net.knacht.bootstrap.application/build.gradle
+++ b/spring-boot-vaadin-multi/net.knacht.bootstrap.application/build.gradle
@@ -1,3 +1,9 @@
+apply plugin: 'spring-boot'
+
+springBoot {
+    mainClass = "net.knacht.bootstrap.application.Application"
+}
+
 // List all of your modules here, in order to be picked up by spring-boot
 dependencies {
     compile project (':net.knacht.bootstrap.application.model')


### PR DESCRIPTION
Updates in spring-vaadin-bootstrap-multi project. Spring's dependency-management plugin is introduced now to import spring boot dependencies defined in BOM, and only use spring-boot plugin in the application subproject. New version are set to exact versions. Gradle to version 3.3, Spring Boot to version 1.5.1.RELEASE, Vaadin to version 7.7.6, Spring Boot Vaadin to version 0.0.5.RELEASE.